### PR TITLE
fix: update permissions to allow write access and add tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -37,6 +37,14 @@ jobs:
           echo "MINOR=$MINOR" >> $GITHUB_ENV
           echo "PATCH=$PATCH" >> $GITHUB_ENV
       
+      - name: Tag and Push Release
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag v${{ env.VERSION }}
+          git push origin v${{ env.VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Description

This PR implements automated Git tagging for our `app` container releases. These changes ensure that every container image published to GHCR corresponds to a permanent, versioned tag in our source code, fulfilling the final requirement for the Excellent grade in Assignment 1.

Key changes:
- Added the contents: `write` permission to the workflow.
- Integrated a new step to configure a Git user and automatically create/push a Git tag based on the version extracted from the `pom.xml`.

## How to Test

- Update the `<version>` tag in `app/pom.xml` and push to main.
- Navigate to the Actions tab in the repository. Open the running workflow and verify that the "Tag and Push Release" step completed successfully.
- Go to the Tags or Releases section of the GitHub repository. Confirm that a new tag matching your version change has been created at the correct commit.
- Check the Packages section of the organization. Verify that the new image tag in the GitHub Container Registry matches the Git tag exactly.