### PR TITLE
A4 metrics tracking for stable version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,13 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build-info</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>sms</groupId>
 	<artifactId>frontend</artifactId>
-	<version>0.0.6</version>
+	<version>0.0.8</version>
 
 	<properties>
 		<java.version>25</java.version>

--- a/src/main/java/frontend/ctrl/FrontendController.java
+++ b/src/main/java/frontend/ctrl/FrontendController.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.DoubleAdder;
 
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import frontend.data.Sms;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 
 @Controller
 @RequestMapping(path = "/sms")
@@ -37,12 +39,23 @@ public class FrontendController {
     private final DoubleAdder histSum = new DoubleAdder();
     private final AtomicLong histCount = new AtomicLong();
 
+    // Buckets: 1.0s, 1.5s, 2.0s, +Inf
+    private final AtomicLong firstRequestHistBucket01 = new AtomicLong();
+    private final AtomicLong firstRequestHistBucket05 = new AtomicLong();
+    private final AtomicLong firstRequestHistBucket10 = new AtomicLong();
+    private final AtomicLong firstRequestHistBucket15 = new AtomicLong();
+    private final AtomicLong firstRequestHistBucket30 = new AtomicLong();
+    private final AtomicLong firstRequestHistBucketInf = new AtomicLong();
+    private final DoubleAdder firstRequestHistSum = new DoubleAdder();
+    private final AtomicLong firstRequestHistCount = new AtomicLong();
+
     private String modelHost;
     private RestTemplateBuilder rest;
 
-    public FrontendController(RestTemplateBuilder rest, Environment env) {
+    public FrontendController(RestTemplateBuilder rest, Environment env, BuildProperties buildProperties) {
         this.rest = rest;
         this.modelHost = env.getProperty("MODEL_HOST");
+        this.version = buildProperties.getVersion();
         assertModelHost();
     }
 
@@ -67,23 +80,26 @@ public class FrontendController {
     }
 
     @GetMapping("/")
-    public String index(Model m) {
+    public String index(Model m, HttpSession session) {
+        // Store the time of page opening
+        session.setAttribute("pageOpenTime", System.nanoTime());
         m.addAttribute("hostname", modelHost);
         return "sms/index";
     }
 
     @PostMapping({ "", "/" })
     @ResponseBody
-    public Sms predict(@RequestBody Sms sms) {
+    public Sms predict(@RequestBody Sms sms, HttpSession session) {
         System.out.printf("Requesting prediction for \"%s\" ...\n", sms.sms);
 
         long startTime = System.nanoTime();
+        long firstReqTime = startTime - (long)session.getAttribute("pageOpenTime");
 
         try {
             sms.result = getPrediction(sms);
         } finally {
             long durationNanos = System.nanoTime() - startTime;
-            recordMetrics(sms.result, sms.sms.length(), durationNanos);
+            recordMetrics(sms.result, sms.sms.length(), durationNanos, firstReqTime);
         }
 
         System.out.printf("Prediction: %s\n", sms.result);
@@ -100,7 +116,7 @@ public class FrontendController {
         }
     }
 
-    private void recordMetrics(String result, int length, long durationNanos) {
+    private void recordMetrics(String result, int length, long durationNanos, long firstReqTime) {
         if ("SPAM".equalsIgnoreCase(result)) {
             counterSpam.incrementAndGet();
         } else {
@@ -117,6 +133,19 @@ public class FrontendController {
         if (durationSeconds <= 0.5) histBucket05.incrementAndGet();
         if (durationSeconds <= 1.0) histBucket10.incrementAndGet();
         histBucketInf.incrementAndGet(); // +Inf always increments
+
+        
+        double firstReqSeconds = firstReqTime / 1_000_000_000.0;
+        firstRequestHistSum.add(firstReqSeconds);
+        firstRequestHistCount.incrementAndGet();
+
+        if (firstReqSeconds <= 1.0) firstRequestHistBucket01.incrementAndGet();
+        if (firstReqSeconds <= 5.0) firstRequestHistBucket05.incrementAndGet();
+        if (firstReqSeconds <= 10.0) firstRequestHistBucket10.incrementAndGet();
+        if (firstReqSeconds <= 15.0) firstRequestHistBucket15.incrementAndGet();
+        if (firstReqSeconds <= 30.0) firstRequestHistBucket30.incrementAndGet();
+        firstRequestHistBucketInf.incrementAndGet(); // +Inf always increments
+
     }
 
     // --- Prometheus endpoint ---
@@ -128,23 +157,35 @@ public class FrontendController {
         // 1. Counter: sms_predictions_total
         sb.append("# HELP sms_predictions_total Total number of prediction requests\n");
         sb.append("# TYPE sms_predictions_total counter\n");
-        sb.append("sms_predictions_total{result=\"spam\"} ").append(counterSpam.get()).append("\n");
-        sb.append("sms_predictions_total{result=\"ham\"} ").append(counterHam.get()).append("\n");
+        sb.append("sms_predictions_total{result=\"spam\",version=\"").append(version).append("\"} ").append(counterSpam.get()).append("\n");
+        sb.append("sms_predictions_total{result=\"ham\",version=\"").append(version).append("\"} ").append(counterHam.get()).append("\n");
 
         // 2. Gauge: sms_last_text_length
         sb.append("# HELP sms_last_text_length Length of the last checked SMS text\n");
         sb.append("# TYPE sms_last_text_length gauge\n");
-        sb.append("sms_last_text_length ").append(gaugeLastLength.get()).append("\n");
+        sb.append("sms_last_text_length{version=\"").append(version).append("\"} ").append(gaugeLastLength.get()).append("\n");
 
         // 3. Histogram: sms_prediction_duration_seconds
         sb.append("# HELP sms_prediction_duration_seconds Prediction latency in seconds\n");
         sb.append("# TYPE sms_prediction_duration_seconds histogram\n");
-        sb.append("sms_prediction_duration_seconds_bucket{le=\"0.1\"} ").append(histBucket01.get()).append("\n");
-        sb.append("sms_prediction_duration_seconds_bucket{le=\"0.5\"} ").append(histBucket05.get()).append("\n");
-        sb.append("sms_prediction_duration_seconds_bucket{le=\"1.0\"} ").append(histBucket10.get()).append("\n");
-        sb.append("sms_prediction_duration_seconds_bucket{le=\"+Inf\"} ").append(histBucketInf.get()).append("\n");
-        sb.append("sms_prediction_duration_seconds_sum ").append(histSum.sum()).append("\n");
-        sb.append("sms_prediction_duration_seconds_count ").append(histCount.get()).append("\n");
+        sb.append("sms_prediction_duration_seconds_bucket{le=\"0.1\",version=\"").append(version).append("\"} ").append(histBucket01.get()).append("\n");
+        sb.append("sms_prediction_duration_seconds_bucket{le=\"0.5\",version=\"").append(version).append("\"} ").append(histBucket05.get()).append("\n");
+        sb.append("sms_prediction_duration_seconds_bucket{le=\"1.0\",version=\"").append(version).append("\"} ").append(histBucket10.get()).append("\n");
+        sb.append("sms_prediction_duration_seconds_bucket{le=\"+Inf\",version=\"").append(version).append("\"} ").append(histBucketInf.get()).append("\n");
+        sb.append("sms_prediction_duration_seconds_sum{version=\"").append(version).append("\"} ").append(histSum.sum()).append("\n");
+        sb.append("sms_prediction_duration_seconds_count{version=\"").append(version).append("\"} ").append(histCount.get()).append("\n");
+
+        // 4. Histogram: first_sms_request_duration_seconds
+        sb.append("# HELP sms_first_request_duration_seconds First request latency in seconds\n");
+        sb.append("# TYPE sms_first_request_duration_seconds histogram\n");
+        sb.append("sms_first_request_duration_seconds_bucket{le=\"1\",version=\"").append(version).append("\"} ").append(firstRequestHistBucket01.get()).append("\n");
+        sb.append("sms_first_request_duration_seconds_bucket{le=\"5\",version=\"").append(version).append("\"} ").append(firstRequestHistBucket05.get()).append("\n");
+        sb.append("sms_first_request_duration_seconds_bucket{le=\"10\",version=\"").append(version).append("\"} ").append(firstRequestHistBucket10.get()).append("\n");
+        sb.append("sms_first_request_duration_seconds_bucket{le=\"15\",version=\"").append(version).append("\"} ").append(firstRequestHistBucket15.get()).append("\n");
+        sb.append("sms_first_request_duration_seconds_bucket{le=\"30\",version=\"").append(version).append("\"} ").append(firstRequestHistBucket30.get()).append("\n");
+        sb.append("sms_first_request_duration_seconds_bucket{le=\"+Inf\",version=\"").append(version).append("\"} ").append(firstRequestHistBucketInf.get()).append("\n");
+        sb.append("sms_first_request_duration_seconds_sum{version=\"").append(version).append("\"} ").append(firstRequestHistSum.sum()).append("\n");
+        sb.append("sms_first_request_duration_seconds_count{version=\"").append(version).append("\"} ").append(firstRequestHistCount.get()).append("\n");
 
         return ResponseEntity.ok().body(sb.toString());
     }

--- a/src/main/java/frontend/ctrl/FrontendController.java
+++ b/src/main/java/frontend/ctrl/FrontendController.java
@@ -51,6 +51,7 @@ public class FrontendController {
 
     private String modelHost;
     private RestTemplateBuilder rest;
+    private String version;
 
     public FrontendController(RestTemplateBuilder rest, Environment env, BuildProperties buildProperties) {
         this.rest = rest;

--- a/src/main/java/frontend/ctrl/FrontendController.java
+++ b/src/main/java/frontend/ctrl/FrontendController.java
@@ -39,7 +39,7 @@ public class FrontendController {
     private final DoubleAdder histSum = new DoubleAdder();
     private final AtomicLong histCount = new AtomicLong();
 
-    // Buckets: 1.0s, 1.5s, 2.0s, +Inf
+    // Buckets: 1s, 5s, 10s, 15s, 30s, +Inf
     private final AtomicLong firstRequestHistBucket01 = new AtomicLong();
     private final AtomicLong firstRequestHistBucket05 = new AtomicLong();
     private final AtomicLong firstRequestHistBucket10 = new AtomicLong();
@@ -49,9 +49,20 @@ public class FrontendController {
     private final DoubleAdder firstRequestHistSum = new DoubleAdder();
     private final AtomicLong firstRequestHistCount = new AtomicLong();
 
+    // Buckets: 1s, 5s, 10s, 15s, 30s, +Inf
+    private final AtomicLong interRequestHistBucket01 = new AtomicLong();
+    private final AtomicLong interRequestHistBucket05 = new AtomicLong();
+    private final AtomicLong interRequestHistBucket10 = new AtomicLong();
+    private final AtomicLong interRequestHistBucket15 = new AtomicLong();
+    private final AtomicLong interRequestHistBucket30 = new AtomicLong();
+    private final AtomicLong interRequestHistBucketInf = new AtomicLong();
+    private final DoubleAdder interRequestHistSum = new DoubleAdder();
+    private final AtomicLong interRequestHistCount = new AtomicLong();
+
     private String modelHost;
     private RestTemplateBuilder rest;
     private String version;
+    private long prevRequestTime;
 
     public FrontendController(RestTemplateBuilder rest, Environment env, BuildProperties buildProperties) {
         this.rest = rest;
@@ -84,7 +95,9 @@ public class FrontendController {
     public String index(Model m, HttpSession session) {
         // Store the time of page opening
         session.setAttribute("pageOpenTime", System.nanoTime());
+        session.setAttribute("firstReq", true);
         m.addAttribute("hostname", modelHost);
+        this.prevRequestTime = System.nanoTime();
         return "sms/index";
     }
 
@@ -95,12 +108,14 @@ public class FrontendController {
 
         long startTime = System.nanoTime();
         long firstReqTime = startTime - (long)session.getAttribute("pageOpenTime");
+        long interRequestTime = startTime - this.prevRequestTime;
+        this.prevRequestTime = startTime;
 
         try {
             sms.result = getPrediction(sms);
         } finally {
             long durationNanos = System.nanoTime() - startTime;
-            recordMetrics(sms.result, sms.sms.length(), durationNanos, firstReqTime);
+            recordMetrics(sms.result, sms.sms.length(), durationNanos, firstReqTime, interRequestTime, session);
         }
 
         System.out.printf("Prediction: %s\n", sms.result);
@@ -117,7 +132,7 @@ public class FrontendController {
         }
     }
 
-    private void recordMetrics(String result, int length, long durationNanos, long firstReqTime) {
+    private void recordMetrics(String result, int length, long durationNanos, long firstReqTime, long interRequestTime, HttpSession session) {
         if ("SPAM".equalsIgnoreCase(result)) {
             counterSpam.incrementAndGet();
         } else {
@@ -135,18 +150,29 @@ public class FrontendController {
         if (durationSeconds <= 1.0) histBucket10.incrementAndGet();
         histBucketInf.incrementAndGet(); // +Inf always increments
 
-        
-        double firstReqSeconds = firstReqTime / 1_000_000_000.0;
-        firstRequestHistSum.add(firstReqSeconds);
-        firstRequestHistCount.incrementAndGet();
+        if((boolean)session.getAttribute("firstReq")) {
+            session.setAttribute("firstReq", false);
+            double firstReqSeconds = firstReqTime / 1_000_000_000.0;
+            firstRequestHistSum.add(firstReqSeconds);
+            firstRequestHistCount.incrementAndGet();
 
-        if (firstReqSeconds <= 1.0) firstRequestHistBucket01.incrementAndGet();
-        if (firstReqSeconds <= 5.0) firstRequestHistBucket05.incrementAndGet();
-        if (firstReqSeconds <= 10.0) firstRequestHistBucket10.incrementAndGet();
-        if (firstReqSeconds <= 15.0) firstRequestHistBucket15.incrementAndGet();
-        if (firstReqSeconds <= 30.0) firstRequestHistBucket30.incrementAndGet();
-        firstRequestHistBucketInf.incrementAndGet(); // +Inf always increments
+            if (firstReqSeconds <= 1.0) firstRequestHistBucket01.incrementAndGet();
+            if (firstReqSeconds <= 5.0) firstRequestHistBucket05.incrementAndGet();
+            if (firstReqSeconds <= 10.0) firstRequestHistBucket10.incrementAndGet();
+            if (firstReqSeconds <= 15.0) firstRequestHistBucket15.incrementAndGet();
+            if (firstReqSeconds <= 30.0) firstRequestHistBucket30.incrementAndGet();
+            firstRequestHistBucketInf.incrementAndGet(); // +Inf always increments
+        }
 
+        double interRequestSeconds = interRequestTime / 1_000_000_000.0;
+        interRequestHistSum.add(interRequestSeconds);
+        interRequestHistCount.incrementAndGet();
+        if (interRequestSeconds <= 1.0) interRequestHistBucket01.incrementAndGet();
+        if (interRequestSeconds <= 5.0) interRequestHistBucket05.incrementAndGet();
+        if (interRequestSeconds <= 10.0) interRequestHistBucket10.incrementAndGet();
+        if (interRequestSeconds <= 15.0) interRequestHistBucket15.incrementAndGet();
+        if (interRequestSeconds <= 30.0) interRequestHistBucket30.incrementAndGet();
+        interRequestHistBucketInf.incrementAndGet(); // +Inf always increments
     }
 
     // --- Prometheus endpoint ---
@@ -187,6 +213,18 @@ public class FrontendController {
         sb.append("sms_first_request_duration_seconds_bucket{le=\"+Inf\",version=\"").append(version).append("\"} ").append(firstRequestHistBucketInf.get()).append("\n");
         sb.append("sms_first_request_duration_seconds_sum{version=\"").append(version).append("\"} ").append(firstRequestHistSum.sum()).append("\n");
         sb.append("sms_first_request_duration_seconds_count{version=\"").append(version).append("\"} ").append(firstRequestHistCount.get()).append("\n");
+
+        // 5. Histogram: inter_sms_request_duration_seconds
+        sb.append("# HELP sms_inter_request_duration_seconds Inter request latency in seconds\n");
+        sb.append("# TYPE sms_inter_request_duration_seconds histogram\n");
+        sb.append("sms_inter_request_duration_seconds_bucket{le=\"1\",version=\"").append(version).append("\"} ").append(interRequestHistBucket01.get()).append("\n");
+        sb.append("sms_inter_request_duration_seconds_bucket{le=\"5\",version=\"").append(version).append("\"} ").append(interRequestHistBucket05.get()).append("\n");
+        sb.append("sms_inter_request_duration_seconds_bucket{le=\"10\",version=\"").append(version).append("\"} ").append(interRequestHistBucket10.get()).append("\n");
+        sb.append("sms_inter_request_duration_seconds_bucket{le=\"15\",version=\"").append(version).append("\"} ").append(interRequestHistBucket15.get()).append("\n");
+        sb.append("sms_inter_request_duration_seconds_bucket{le=\"30\",version=\"").append(version).append("\"} ").append(interRequestHistBucket30.get()).append("\n");
+        sb.append("sms_inter_request_duration_seconds_bucket{le=\"+Inf\",version=\"").append(version).append("\"} ").append(interRequestHistBucketInf.get()).append("\n");
+        sb.append("sms_inter_request_duration_seconds_sum{version=\"").append(version).append("\"} ").append(interRequestHistSum.sum()).append("\n");
+        sb.append("sms_inter_request_duration_seconds_count{version=\"").append(version).append("\"} ").append(interRequestHistCount.get()).append("\n");
 
         return ResponseEntity.ok().body(sb.toString());
     }


### PR DESCRIPTION
Added the version used to the metrics.
Changed version to 0.0.8 (used as stable version for the continuous experimentation)
Added the following metrics to track:

- Histogram tracking time to first request made.
    - Sum of total seconds of the first requests made.
    - Count of total first requests made.
- Histogram of time between each request made in seconds.
    - Sum of total seconds of the inter requests made.
    - Count of total inter requests made.
- Counter of total amount of pages that were abandoned with no request made.

---

Using the quick start in the README:

Build the image (requires GitHub Packages credentials as build args):

```
docker build \
  --build-arg GITHUB_USERNAME=<github_username> \
  --build-arg GITHUB_TOKEN='<token_with_read:packages_and_SSO>' \
  -t app-service:local .
```

Run locally:

```
docker run --rm -p 8080:8080 \
  -e MODEL_HOST=http://localhost:8081 \
  app-service:local
```

Check the metrics in: http://localhost:8080/sms/metrics
Expected:
<img width="605" height="587" alt="image" src="https://github.com/user-attachments/assets/ee16a9ee-f459-47c2-bdb9-d43db9c46fbb" />


Feel free to make some random requests in http://localhost:8080/sms and reload the metrics page to see the changes.
