### PR TITLE
Added sms_upstream_errors_total and sms_input_length_histogram metrics

### DIFF
--- a/src/main/java/frontend/ctrl/FrontendController.java
+++ b/src/main/java/frontend/ctrl/FrontendController.java
@@ -2,6 +2,7 @@ package frontend.ctrl;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.DoubleAdder;
 
@@ -154,7 +155,11 @@ public class FrontendController {
     private String getPrediction(Sms sms) {
         try {
             var url = new URI(modelHost + "/predict");
-            var c = rest.build().postForEntity(url, sms, Sms.class);
+            var c = rest
+                    .setConnectTimeout(Duration.ofSeconds(3))
+                    .setReadTimeout(Duration.ofSeconds(3))
+                    .build()
+                    .postForEntity(url, sms, Sms.class);
             return c.getBody().result.trim();
         } catch (Exception e) {
             counterUpstreamErrors.incrementAndGet();
@@ -181,7 +186,7 @@ public class FrontendController {
         if (durationSeconds <= 0.1) histBucket01.incrementAndGet();
         if (durationSeconds <= 0.5) histBucket05.incrementAndGet();
         if (durationSeconds <= 1.0) histBucket10.incrementAndGet();
-        histBucketInf.incrementAndGet(); // +Inf always increments
+        histBucketInf.incrementAndGet();
 
         Boolean firstReq = (Boolean)session.getAttribute("firstReq");
         if(firstReq != null && firstReq) {
@@ -195,7 +200,7 @@ public class FrontendController {
             if (firstReqSeconds <= 10.0) firstRequestHistBucket10.incrementAndGet();
             if (firstReqSeconds <= 15.0) firstRequestHistBucket15.incrementAndGet();
             if (firstReqSeconds <= 30.0) firstRequestHistBucket30.incrementAndGet();
-            firstRequestHistBucketInf.incrementAndGet(); // +Inf always increments
+            firstRequestHistBucketInf.incrementAndGet();
         }
 
         double interRequestSeconds = interRequestTime / 1_000_000_000.0;
@@ -206,7 +211,7 @@ public class FrontendController {
         if (interRequestSeconds <= 10.0) interRequestHistBucket10.incrementAndGet();
         if (interRequestSeconds <= 15.0) interRequestHistBucket15.incrementAndGet();
         if (interRequestSeconds <= 30.0) interRequestHistBucket30.incrementAndGet();
-        interRequestHistBucketInf.incrementAndGet(); // +Inf always increments
+        interRequestHistBucketInf.incrementAndGet();
 
         Boolean hasMadePrediction = (Boolean)session.getAttribute("hasMadePrediction");
         if (hasMadePrediction != null && !hasMadePrediction) {
@@ -221,7 +226,7 @@ public class FrontendController {
         if (length <= 50) lengthBucket50.incrementAndGet();
         if (length <= 100) lengthBucket100.incrementAndGet();
         if (length <= 160) lengthBucket160.incrementAndGet();
-        lengthBucketInf.incrementAndGet(); // +Inf always increments
+        lengthBucketInf.incrementAndGet();
     }
 
     // --- Prometheus endpoint ---


### PR DESCRIPTION
# New Metrics Added

## sms_upstream_errors_total (Counter)
- Tracks the total number of failed requests to the upstream model-service to detect when the model service is down or unreachable, distinguishing these failures from other application errors. It increments whenever the  getPrediction call throws an exception (e.g., connection refused, timeout).

## sms_input_length_histogram (Histogram)
- Buckets: 10, 50, 100, 160, +Inf
- Measures the distribution of the character length of submitted SMS messages to understand user behavior (e.g., "Are most users sending short <10 char messages or long ones?"). Might potentially help to improve the model (or UI, maybe text field is buggy).

## How to Test

### Prerequisites
- Docker and Docker Compose installed.
- Valid  `operation/.env` with GitHub credentials (for lib-version dependency).
- Create a temporary `docker-compose.local.yml` for testing (that pulls local images) from `app` and `model-service`.

### Steps
1. Run `docker compose -f docker-compose.local.yml up --build` from `operation` repo.
2. Generate Data:
    * Go to `http://localhost:8080/sms`. Also open ``http://localhost:8080/sms/metrics`.
    * Submit a short message ("Hello") -> Falls into le="10" bucket.
    * Submit a longer message (>10 chars).
    * Restart metrics and you should see updates. Histograms are cumulative, so if the message is too short, it will fall in all buckets.
3. Generate Errors:
    * Stop the `model-service` by running `docker-compose -f docker-compose.local.yml pause model-service`.
    * Submit another messages few times. It should fail (but it doesn't, we don't print any error messages), but count towards the metric. You won't see any updates related to `sms_upstream_errors_total`.
    * Start `model-service` by running `docker-compose -f docker-compose.local.yml unpause model-service` and reload the metrics page. You should see the number of errors equivalent to the number of requests while `model-service` was stopped.