### PR TITLE
Time_On_Page metric

### DIFF
--- a/src/main/java/frontend/ctrl/FrontendController.java
+++ b/src/main/java/frontend/ctrl/FrontendController.java
@@ -226,14 +226,11 @@ public class FrontendController {
         }
         session.setAttribute("sessionMetricsRecorded", true);
 
-        double timeSpentSeconds = 0.0;
-        Object openObj = session.getAttribute("pageOpenTime");
-        if (openObj instanceof Long) {
-            long open = (Long) openObj;
-            timeSpentSeconds = (System.nanoTime() - open) / 1_000_000_000.0;
-        } else if (report != null && report.timeSpentSeconds != null) {
-            timeSpentSeconds = report.timeSpentSeconds;
+        if (report == null || report.timeSpentSeconds == null || report.timeSpentSeconds.isNaN() || report.timeSpentSeconds < 0.0) {
+            return ResponseEntity.ok().build();
         }
+
+        double timeSpentSeconds = report.timeSpentSeconds;
 
         timeOnPageSum.add(timeSpentSeconds);
         timeOnPageCount.incrementAndGet();
@@ -244,7 +241,6 @@ public class FrontendController {
         if (timeSpentSeconds <= 60) timeOnPageBucket60.incrementAndGet();
         if (timeSpentSeconds <= 120) timeOnPageBucket120.incrementAndGet();
         timeOnPageBucketInf.incrementAndGet();
-
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/frontend/ctrl/FrontendController.java
+++ b/src/main/java/frontend/ctrl/FrontendController.java
@@ -59,6 +59,18 @@ public class FrontendController {
     private final DoubleAdder interRequestHistSum = new DoubleAdder();
     private final AtomicLong interRequestHistCount = new AtomicLong();
 
+    // Buckets: 5s, 10s, 20s, 30s, 60s, 120s, +Inf
+    private final AtomicLong timeOnPageBucket05 = new AtomicLong();
+    private final AtomicLong timeOnPageBucket10 = new AtomicLong();
+    private final AtomicLong timeOnPageBucket20 = new AtomicLong();
+    private final AtomicLong timeOnPageBucket30 = new AtomicLong();
+    private final AtomicLong timeOnPageBucket60 = new AtomicLong();
+    private final AtomicLong timeOnPageBucket120 = new AtomicLong();
+    private final AtomicLong timeOnPageBucketInf = new AtomicLong();
+    private final DoubleAdder timeOnPageSum = new DoubleAdder();
+    private final AtomicLong timeOnPageCount = new AtomicLong();
+
+
     private final RestTemplateBuilder rest;
     private final AtomicLong pageAbandoned = new AtomicLong();
     private final String version;
@@ -98,6 +110,7 @@ public class FrontendController {
         // Store the time of page opening
         session.setAttribute("pageOpenTime", System.nanoTime());
         session.setAttribute("firstReq", true);
+        session.setAttribute("sessionMetricsRecorded", false);
 
         pageAbandoned.incrementAndGet();
         session.setAttribute("hasMadePrediction", false);
@@ -118,6 +131,7 @@ public class FrontendController {
             session.setAttribute("pageOpenTime", startTime);
             session.setAttribute("firstReq", true);
             session.setAttribute("hasMadePrediction", false);
+            session.setAttribute("sessionMetricsRecorded", false);
             pageAbandoned.incrementAndGet();
             prevRequestTime = System.nanoTime();
         }
@@ -198,6 +212,44 @@ public class FrontendController {
         }
     }
 
+    public static class SessionReport {
+        public Double timeSpentSeconds;
+    }
+
+    @PostMapping(value = "/session", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public ResponseEntity<Void> reportSession(@RequestBody(required = false) SessionReport report, HttpSession session) {
+
+        Boolean alreadyRecorded = (Boolean) session.getAttribute("sessionMetricsRecorded");
+        if (alreadyRecorded != null && alreadyRecorded) {
+            return ResponseEntity.ok().build();
+        }
+        session.setAttribute("sessionMetricsRecorded", true);
+
+        double timeSpentSeconds = 0.0;
+        Object openObj = session.getAttribute("pageOpenTime");
+        if (openObj instanceof Long) {
+            long open = (Long) openObj;
+            timeSpentSeconds = (System.nanoTime() - open) / 1_000_000_000.0;
+        } else if (report != null && report.timeSpentSeconds != null) {
+            timeSpentSeconds = report.timeSpentSeconds;
+        }
+
+        timeOnPageSum.add(timeSpentSeconds);
+        timeOnPageCount.incrementAndGet();
+        if (timeSpentSeconds <= 5) timeOnPageBucket05.incrementAndGet();
+        if (timeSpentSeconds <= 10) timeOnPageBucket10.incrementAndGet();
+        if (timeSpentSeconds <= 20) timeOnPageBucket20.incrementAndGet();
+        if (timeSpentSeconds <= 30) timeOnPageBucket30.incrementAndGet();
+        if (timeSpentSeconds <= 60) timeOnPageBucket60.incrementAndGet();
+        if (timeSpentSeconds <= 120) timeOnPageBucket120.incrementAndGet();
+        timeOnPageBucketInf.incrementAndGet();
+
+
+        return ResponseEntity.ok().build();
+    }
+
+
     // --- Prometheus endpoint ---
     @GetMapping(value = "/metrics", produces = MediaType.TEXT_PLAIN_VALUE)
     @ResponseBody
@@ -253,6 +305,21 @@ public class FrontendController {
         sb.append("# HELP sms_pages_abandoned_total Total number of abandoned SMS pages\n");
         sb.append("# TYPE sms_pages_abandoned_total counter\n");
         sb.append("sms_pages_abandoned_total{version=\"").append(version).append("\"} ").append(pageAbandoned.get()).append("\n");
+
+
+        // 7. Histogram: sms_time_on_page_seconds
+        sb.append("# HELP sms_time_on_page_seconds Time a user spends on the page (seconds)\n");
+        sb.append("# TYPE sms_time_on_page_seconds histogram\n");
+        sb.append("sms_time_on_page_seconds_bucket{le=\"5\",version=\"").append(version).append("\"} ").append(timeOnPageBucket05.get()).append("\n");
+        sb.append("sms_time_on_page_seconds_bucket{le=\"10\",version=\"").append(version).append("\"} ").append(timeOnPageBucket10.get()).append("\n");
+        sb.append("sms_time_on_page_seconds_bucket{le=\"20\",version=\"").append(version).append("\"} ").append(timeOnPageBucket20.get()).append("\n");
+        sb.append("sms_time_on_page_seconds_bucket{le=\"30\",version=\"").append(version).append("\"} ").append(timeOnPageBucket30.get()).append("\n");
+        sb.append("sms_time_on_page_seconds_bucket{le=\"60\",version=\"").append(version).append("\"} ").append(timeOnPageBucket60.get()).append("\n");
+        sb.append("sms_time_on_page_seconds_bucket{le=\"120\",version=\"").append(version).append("\"} ").append(timeOnPageBucket120.get()).append("\n");
+        sb.append("sms_time_on_page_seconds_bucket{le=\"+Inf\",version=\"").append(version).append("\"} ").append(timeOnPageBucketInf.get()).append("\n");
+        sb.append("sms_time_on_page_seconds_sum{version=\"").append(version).append("\"} ").append(timeOnPageSum.sum()).append("\n");
+        sb.append("sms_time_on_page_seconds_count{version=\"").append(version).append("\"} ").append(timeOnPageCount.get()).append("\n");
+
 
         return ResponseEntity.ok().body(sb.toString());
     }

--- a/src/main/resources/static/sms/script.js
+++ b/src/main/resources/static/sms/script.js
@@ -1,86 +1,119 @@
 $(document).ready(function() {
 
-    var pageStartMs = Date.now();
-    var sessionReported = false;
+// --- Active tab time tracking: counts only while tab is visible + focused ---
+    (function () {
+        let activeMs = 0;
+        let activeStartMs = null;
+        let sessionReported = false;
 
-    function reportSession() {
-        if (sessionReported) return;
-        sessionReported = true;
-
-        var payload = JSON.stringify({
-            timeSpentSeconds: (Date.now() - pageStartMs) / 1000.0
-        });
-
-        if (navigator.sendBeacon) {
-            navigator.sendBeacon("./session", new Blob([payload], { type: "application/json" }));
-        } else {
-            fetch("./session", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: payload,
-                keepalive: true
-            });
+        function isActiveNow() {
+            return document.visibilityState === "visible" && document.hasFocus();
         }
-    }
 
-    window.addEventListener("pagehide", reportSession);
-    window.addEventListener("beforeunload", reportSession);
+        function startActive() {
+            if (activeStartMs === null) {
+                activeStartMs = performance.now();
+            }
+        }
+
+        function stopActive() {
+            if (activeStartMs !== null) {
+                activeMs += (performance.now() - activeStartMs);
+                activeStartMs = null;
+            }
+        }
+
+        function syncActiveState() {
+            if (isActiveNow()) startActive();
+            else stopActive();
+        }
+
+        document.addEventListener("visibilitychange", syncActiveState, true);
+        window.addEventListener("focus", syncActiveState, true);
+        window.addEventListener("blur", syncActiveState, true);
+        window.addEventListener("pageshow", syncActiveState, true); // helps with bfcache restores
+
+        function reportSession() {
+            if (sessionReported) return;
+            sessionReported = true;
+
+            stopActive();
+
+            const payload = JSON.stringify({ timeSpentSeconds: activeMs / 1000.0 });
+
+            if (navigator.sendBeacon) {
+                navigator.sendBeacon("/sms/session", new Blob([payload], { type: "application/json" }));
+            } else {
+                fetch("/sms/session", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: payload,
+                    keepalive: true
+                });
+            }
+        }
+
+        window.addEventListener("pagehide", reportSession, true);
+        window.addEventListener("beforeunload", reportSession, true);
+
+        syncActiveState();
+    })();
 
 
     function getSMS() {
-		return $("textarea").val().trim()
-	}
-	
-	function getGuess() {
-		return $("input[name='guess']:checked").val().trim()
-	}
-	
-	function cleanResult() {
-		$("#result").removeClass("correct")
-		$("#result").removeClass("incorrect")
-		$("#result").removeClass("error")
-		$("#result").html()
-	}
+        return $("textarea").val().trim()
+    }
 
-	$("button").click(function (e) {
-		e.stopPropagation()
-		e.preventDefault()
+    function getGuess() {
+        return $("input[name='guess']:checked").val().trim()
+    }
 
-		var sms = getSMS()
-		var guess = getGuess()
-		
-		$.ajax({
-			type: "POST",
-			url: "./",
-			data: JSON.stringify({"sms": sms, "guess": guess}),
-			contentType: "application/json",
-			dataType: "json",
-			success: handleResult,
-			error: handleError	
-		})
-	})
+    function cleanResult() {
+        $("#result").removeClass("correct")
+        $("#result").removeClass("incorrect")
+        $("#result").removeClass("error")
+        $("#result").html()
+    }
 
-	function handleResult(res) {
-		var wasRight = res.result == getGuess()
+    $("button").click(function (e) {
+        e.stopPropagation()
+        e.preventDefault()
 
-		cleanResult()		
-		$("#result").addClass(wasRight ? "correct" : "incorrect")
-		$("#result").html("The classifier " + (wasRight ? "agrees" : "disagrees"))		
-		$("#result").show()
-	}
-	
-	function handleError(e) {
-		cleanResult()		
-		$("#result").addClass("error")
-		$("#result").html("An error occured (see server log).")
-		$("#result").show()
-	}
-	
-	$("textarea").on('keypress',function(e) {
-		$("#result").hide()
-	})
-	
-	$("input").click(function(e) {
-		$("#result").hide()
-	})
+        var sms = getSMS()
+        var guess = getGuess()
+
+        $.ajax({
+            type: "POST",
+            url: "./",
+            data: JSON.stringify({"sms": sms, "guess": guess}),
+            contentType: "application/json",
+            dataType: "json",
+            success: handleResult,
+            error: handleError
+        })
+    })
+
+    function handleResult(res) {
+        var wasRight = res.result == getGuess()
+
+        cleanResult()
+        $("#result").addClass(wasRight ? "correct" : "incorrect")
+        $("#result").html("The classifier " + (wasRight ? "agrees" : "disagrees"))
+        $("#result").show()
+    }
+
+    function handleError(e) {
+        cleanResult()
+        $("#result").addClass("error")
+        $("#result").html("An error occured (see server log).")
+        $("#result").show()
+    }
+
+    $("textarea").on('keypress',function(e) {
+        $("#result").hide()
+    })
+
+    $("input").click(function(e) {
+        $("#result").hide()
+    })
 })

--- a/src/main/resources/static/sms/script.js
+++ b/src/main/resources/static/sms/script.js
@@ -1,6 +1,33 @@
 $(document).ready(function() {
 
-	function getSMS() {
+    var pageStartMs = Date.now();
+    var sessionReported = false;
+
+    function reportSession() {
+        if (sessionReported) return;
+        sessionReported = true;
+
+        var payload = JSON.stringify({
+            timeSpentSeconds: (Date.now() - pageStartMs) / 1000.0
+        });
+
+        if (navigator.sendBeacon) {
+            navigator.sendBeacon("./session", new Blob([payload], { type: "application/json" }));
+        } else {
+            fetch("./session", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: payload,
+                keepalive: true
+            });
+        }
+    }
+
+    window.addEventListener("pagehide", reportSession);
+    window.addEventListener("beforeunload", reportSession);
+
+
+    function getSMS() {
 		return $("textarea").val().trim()
 	}
 	


### PR DESCRIPTION
### New Metric Added

#### `sms_time_on_page_seconds` (Histogram)

Tracks **how long users stay on the `/sms/` page per session**, measured in seconds.

* **Buckets:** `5, 10, 20, 30, 60, 120, +Inf`
* Recorded when the user **leaves the page** (via `pagehide` / `beforeunload` in the browser). The backend prefers server-side timing (`now - pageOpenTime`) and uses the client payload only as a fallback.

---

## How to Test

### Prerequisites

* Docker + Docker Compose installed
* Operation repo has valid GitHub credentials in `.env` (needed to build the app because of the `lib-version` dependency):

Add to `operation/.env`:

```env
GITHUB_USERNAME=...
GITHUB_TOKEN=...
```

### Local docker compose override

Create `docker-compose.local.yml` (in the **operation repo**) to build the app from your local filesystem:

```yaml
services:
  app:
    build:
      context: <your_path_to_app>
      dockerfile: Dockerfile
      args:
        GITHUB_USERNAME: ${GITHUB_USERNAME}
        GITHUB_TOKEN: ${GITHUB_TOKEN}
    image: app-local:test
    pull_policy: never
```

### Steps

1. From the **operation repo**, run:

   ```bash
   docker compose --env-file .env -f docker-compose.yml -f docker-compose.local.yml up --build
   ```

2. Open two tabs:

   * UI: `http://localhost:8080/sms/`
   * Metrics: `http://localhost:8080/sms/metrics`

3. In the metrics tab, confirm the metric exists:

   * Search for: `sms_time_on_page_seconds`

4. **In /sms**

   1. Open `/sms/`
   2. Wait **~6 seconds**
   3. Close the tab (or navigate away)
   4. Refresh the metrics tab

   Expected:

   * `sms_time_on_page_seconds_count{...}` increases by **+1**
   * `sms_time_on_page_seconds_sum{...}` increases by approximately **+6**
   * Histogram bucket increments will include `le="10"`, `le="20"`, … (buckets are cumulative)




