### PR TITLE
chore: bump version to 0.0.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>sms</groupId>
 	<artifactId>frontend</artifactId>
-	<version>0.0.11</version>
+	<version>0.0.12</version>
 
 	<properties>
 		<java.version>25</java.version>


### PR DESCRIPTION
Apparently tag `0.0.11` already exists, so I updated version to `0.0.12`. In `operation` I also updated versions accordingly.